### PR TITLE
Change `"monospace"` to `monospace` in index.less

### DIFF
--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -31,7 +31,7 @@ body {
 		"Go Mono",
 		"DejaVu Sans Mono",
 		"Lucida Console",
-		"monospace"
+		monospace
 	;
 }
 


### PR DESCRIPTION
index.less had `"monospace"` written instead of `monospace`, which meant there was no fallback font - thus calling a fallback to e.g. `serif` or whatever. I changed it to `monospace` so it should now correctly fall back to the system monospace font.